### PR TITLE
Update README.md workflow example to adjust updated runtime.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ permissions:
   contents: read # write if pyinstaller-binary-name is non-empty
 jobs:
   MCVS-python-action:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4.1.1
       - uses: schubergphilis/mcvs-python-action@v0.1.1


### PR DESCRIPTION
- Recently got a error warning that my used runtime (Ubuntu 20.04) was being retired. Updated it in my workflow and thought it would be a good idea to change the example in the README.md as well.

Warning message:
This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15.